### PR TITLE
Refine Tailwind enhancement playbook

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,32 @@
+# Repository Audit
+
+## Overview
+- **Repository**: star-player-awards
+- **Scope**: Static single-page voting app (`index.html`), offline assets, and service worker. No build tooling.
+- **Audit Date**: 2025-10-13
+
+## High-Risk Findings
+1. **Hard-coded admin password in client bundle** – The password `zsbf12` is embedded directly in the HTML and JavaScript, allowing anyone with source access to unlock the admin view and manipulate attendance, votes, or session data. 【F:index.html†L389-L393】【F:index.html†L874-L879】
+2. **Unauthenticated Firebase realtime database usage** – The client initializes Firebase with full realtime database access using public credentials but enforces no authentication. Any user who inspects the bundle can reuse the configuration to read or write arbitrary session data, including attendance, votes, and reveal triggers. 【F:index.html†L419-L520】
+3. **Personally identifiable attendance data stored in localStorage without safeguards** – Names, attendance status, and voting history are persisted to localStorage/sessionStorage without consent prompts or clear retention limits. Devices shared among users can leak previous sessions or expose staff identities. 【F:index.html†L434-L481】
+
+## Medium-Risk Findings
+1. **Inaccurate or stale repository documentation** – The README and CLAUDE guidance do not reflect the Firebase-backed architecture or security considerations, increasing onboarding risk and likelihood of misconfiguration. 【F:README.md†L1-L1】【F:CLAUDE.md†L1-L34】
+2. **Service worker cache strategy risks stale critical data** – The cache-first strategy for all non-navigation requests can serve outdated JavaScript/HTML fragments (including Firebase config and password) after updates. Without a cache busting strategy, users may remain on old builds indefinitely. 【F:service-worker.js†L1-L19】
+3. **Session selection allows unvalidated identifiers** – Admins can switch `sessionId` to arbitrary strings which are then used as Firebase paths without validation, risking accidental collisions or path issues when unsupported characters are entered. 【F:index.html†L486-L520】【F:index.html†L906-L935】
+
+## Low-Risk / Observational Findings
+1. **Accessibility gaps in modal implementation** – Modals toggle visibility but do not trap focus, update `aria-hidden`, or restore focus, making keyboard and assistive technology navigation difficult. 【F:index.html†L372-L412】【F:index.html†L851-L888】
+2. **Performance optimization opportunities** – All styles and scripts live inline in `index.html`, preventing browser caching across navigations and blocking early render. Moving assets to separate files or adopting build tooling would improve repeat load times. 【F:index.html†L1-L940】
+3. **Limited PWA metadata** – The manifest declares only a 192×192 icon and lacks maskable icons or screenshots, reducing install quality on Android and desktop. 【F:manifest.json†L1-L11】
+
+## Recommendations
+- Replace the hard-coded admin password with a secure authentication flow (e.g., Firebase Auth, Identity Platform, or at minimum environment-specific secrets loaded server-side). Revoke the exposed credentials.
+- Configure Firebase realtime database security rules to enforce per-session read/write permissions and require authenticated identities for admin operations.
+- Implement data minimization: avoid persisting identifiable attendance data to localStorage, or encrypt data and provide clear retention controls.
+- Update project documentation to describe the current architecture, deployment, and security expectations. Remove or revise stale CLAUDE guidance.
+- Adjust the service worker to use cache busting (revisioned asset URLs) or a stale-while-revalidate strategy, and provide a manual update path.
+- Validate and sanitize session identifiers before using them as database paths; surface helpful error messages for invalid characters.
+- Improve accessibility by adding focus management, role/aria attributes, and keyboard handling for modals.
+- Consider modularizing CSS/JS and introducing basic build tooling to enable caching and linting.
+- Expand the web manifest with additional icon sizes (including maskable variants) and optional shortcuts/screenshots for better install UX.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# ry-zen2.github.io
+# Star Player Awards – Visual Enhancement Playbook
+
+The Star Player Awards site is delivered as a static GitHub Pages deployment. Everything — HTML, inline styles, Firebase logic, manifest, and service worker — lives directly in this repository with no external build tooling. That constraint means every aesthetic enhancement must be satisfied by files tracked in Git and served verbatim by GitHub Pages (or by adding safe CDN links).
+
+## Constraints and Goals
+- **Platform immutability**: We cannot replace GitHub Pages or introduce a server-side build step. Assets must be committed or referenced via CDN.
+- **Single-file architecture**: The production `index.html` owns layout, scripts, and most CSS. Any new framework or utility layer has to coexist with the inline logic.
+- **Collaborator friendliness**: Designers should be able to preview changes locally with only a browser; developers should avoid manual rebuild churn where possible.
+- **Performance & reliability**: Enhancements should avoid bloating payloads or breaking the Firebase-powered interactions already in place.
+
+## Option Matrix (Tailwind-style Enhancements)
+| Approach | Setup Effort | Bundle Impact | Best For |
+| --- | --- | --- | --- |
+| **Tailwind Play CDN** | ⬤ (drop-in script tag) | Higher CSS payload, no purging | Rapid prototyping, hackathon polish |
+| **Locally precompiled Tailwind CSS** | ⬤⬤ (local CLI run before commit) | Purged production CSS | Production-ready styling with tight control |
+| **GitHub Actions build-to-branch** | ⬤⬤⬤ (configure CI workflow) | Same as precompiled, but automated | Teams wanting zero local build steps |
+| **Utility component CDN kits** (DaisyUI, Flowbite) | ⬤ (link + class usage) | Moderate; depends on kit | Quickly dropping in rich widgets/animations |
+| **Hand-tuned bespoke CSS** | ⬤⬤ (author and curate) | Minimal, tailored | When you need complete control or custom visuals |
+
+## Implementation Playbooks
+### 1. Tailwind Play CDN (fastest experiment)
+1. Insert the official Tailwind Play CDN script before the closing `</head>` in `index.html`.
+2. Define any custom Tailwind config (colors, fonts) inline via `tailwind.config = { ... }`.
+3. Use Tailwind utility classes directly in the markup to prototype gradients, glassmorphism, or spacing improvements.
+4. Audit payload size; if the CSS weight becomes an issue, graduate to a compiled build.
+
+**Pros**
+- Zero tooling; perfect for short-lived events or immediate design spikes.
+- Enables modern effects (backdrops, animations) without rewriting CSS by hand.
+
+**Considerations**
+- Utilities are generated on-the-fly in the browser — unused classes are not purged.
+- Avoid using it for long-term production unless payload size is acceptable.
+
+### 2. Precompiled Tailwind CSS committed to the repo
+1. Install Tailwind locally (Node CLI or standalone binary) and create a `tailwind.config.js` tailored to the app's palette/typography.
+2. Extract the HTML into a temporary template file or point the Tailwind CLI at `index.html` so it can tree-shake used utilities.
+3. Run `npx tailwindcss -i ./tailwind.css -o ./assets/tailwind.min.css --minify` (or equivalent) and commit the resulting CSS asset.
+4. Link the compiled CSS from `index.html` (`<link rel="stylesheet" href="assets/tailwind.min.css">`) and keep critical overrides inline if necessary.
+5. Document the manual build step (e.g., in `CONTRIBUTING.md`) so contributors regenerate the CSS whenever utility usage changes.
+
+**Pros**
+- Fully purged CSS keeps payload lean.
+- Supports Tailwind plugins (typography, forms, aspect-ratio) and custom themes.
+
+**Considerations**
+- Requires discipline to rebuild the CSS before each commit touching utilities.
+- Store generated assets (e.g., under `assets/`) to keep the repo tidy.
+
+### 3. GitHub Actions build-to-branch workflow
+1. Add a `.github/workflows/build-tailwind.yml` pipeline that runs Tailwind on push (or when `index.html`/`tailwind.css` changes).
+2. Use the workflow to commit the built CSS into a `dist/` directory or push directly to the `gh-pages` branch.
+3. Keep the source Tailwind files (`tailwind.css`, `tailwind.config.js`) in the repo so local preview remains possible.
+
+**Pros**
+- Eliminates manual build errors; everyone pushes source and lets CI produce artifacts.
+- Enables future automation (linting, HTML minification) without changing hosting.
+
+**Considerations**
+- Requires GitHub Actions permissions and careful commit configuration to avoid loops.
+- Debugging builds can be slower than manual CLI runs.
+
+### 4. Utility component libraries via CDN
+1. Choose a Tailwind-flavored kit (DaisyUI, Flowbite, HyperUI, Preline) that matches the desired aesthetic.
+2. Reference the library's CSS/JS CDN links in `index.html`.
+3. Apply provided class combinations to existing markup (cards, modals, buttons) to refresh visuals quickly.
+4. Layer custom CSS variables or overrides if brand colors need tweaking.
+
+**Pros**
+- Ready-made components shrink design time dramatically.
+- Some kits bundle animations, dark mode toggles, and form states.
+
+**Considerations**
+- Verify licenses for commercial usage.
+- May inherit a specific design language that requires additional customization.
+
+### 5. Hand-tuned bespoke CSS enhancements
+1. Modularize critical styles into dedicated `<style>` blocks or external CSS files for maintainability.
+2. Introduce CSS custom properties for brand colors and spacing to ease future theming.
+3. Leverage modern layout features (CSS Grid, clamp-based typography) and add tasteful animations (e.g., keyframes, `scroll-behavior`).
+4. Use tools like [Animista](https://animista.net/) or [UI Gradients](https://uigradients.com/) for inspiration while keeping dependencies zero.
+
+**Pros**
+- Maximum control, no dependency risk.
+- Easy to reason about performance footprint.
+
+**Considerations**
+- Slower to iterate, relies on designer/developer discipline for consistency.
+
+## Recommended Path
+1. **Prototype quickly with the Tailwind Play CDN** during design spikes to validate look and feel without overhead.
+2. **Transition to precompiled Tailwind CSS** once the aesthetic direction solidifies, keeping the generated file under version control.
+3. **Automate via GitHub Actions** if build churn becomes painful or more contributors join.
+4. **Augment with select component kits** when you need advanced UI pieces (timelines, accordions) that would be time-consuming to craft from scratch.
+
+## Checklist Before Rolling Out Styling Changes
+- [ ] Confirm Firebase interactions, modals, and admin flows still function after class changes.
+- [ ] Test offline behavior with the service worker to ensure new assets are cached (update the pre-cache list if needed).
+- [ ] Audit the rendered bundle size (Lighthouse or Chrome DevTools coverage) to verify acceptable performance.
+- [ ] Document any new utility conventions or theme tokens for future maintainers.
+- [ ] Coordinate with content stakeholders so visual updates land before live events.
+
+This playbook keeps the deployment model untouched while opening multiple paths to deliver modern, polished visuals directly from GitHub.


### PR DESCRIPTION
## Summary
- restructure the README into a visual enhancement playbook tailored to the GitHub Pages constraints
- document detailed playbooks for Tailwind CDN usage, precompiled assets, CI automation, component kits, and bespoke CSS options
- add comparison matrix, recommended path, and rollout checklist to guide aesthetic upgrades without altering hosting

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ecab775384832b84b84d6475759698