### PR TITLE
Sync reveal drumroll countdown to Firebase server time

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,6 +463,8 @@ let sessionPin = '';
 let pinEnabled = false;
 let lastDrumSeen = Number(localStorage.getItem(LS.drum + sessionId) || 0);
 let soundsEnabled = localStorage.getItem(LS.snd) !== '0';
+let serverTimeOffsetMs = 0;
+function serverNow(){ return Date.now() + serverTimeOffsetMs; }
 
 /* ====== Firebase Sync ====== */
 const SYNC = (()=>{
@@ -471,7 +473,9 @@ const SYNC = (()=>{
     const cfg = window.BF_SYNC || {};
     if(!cfg.firebaseConfig || !cfg.sessionId){ return; }
     try{ firebase.apps.length ? firebase.app() : firebase.initializeApp(cfg.firebaseConfig); }catch(e){}
-    db = firebase.database(); setSession(cfg.sessionId || 'demo');
+    db = firebase.database();
+    db.ref('.info/serverTimeOffset').on('value', s=> { serverTimeOffsetMs = Number(s.val() || 0); });
+    setSession(cfg.sessionId || 'demo');
   }
   function setSession(id){
     detach(); sessionId = id || 'demo'; localStorage.setItem(LS.session, sessionId);
@@ -736,7 +740,7 @@ function spawnConfetti(opts={}){ const el = document.createElement('div'); el.cl
 
 /* Drumroll overlay — synced via revealStartAt */
 function revealOverlaySync(serverTs){
-  const now = Date.now();
+  const now = serverNow();
   let remain = Math.max(0, Math.ceil(10 - (now - serverTs)/1000));
   const o = document.createElement('div'); o.className='drumroll';
   o.innerHTML = `<div class="drumroll-text">Drum roll…</div><div class="countdown" id="dr-count">${remain}</div><div class="drumroll-bar"><div class="bar-fill" id="dr-fill" style="width:${(10-remain)*10}%"></div></div>`;


### PR DESCRIPTION
### Motivation
- Ensure the drumroll/reveal countdown is synchronized across clients by using Firebase server time offset instead of each client's local clock.

### Description
- Add `serverTimeOffsetMs` and `serverNow()` helper and subscribe to `db.ref('.info/serverTimeOffset')` to keep the offset up-to-date.
- Replace `Date.now()` with `serverNow()` in `revealOverlaySync` so the remaining countdown is computed from server time.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1e148644832b93b5ad5dd94c6680)